### PR TITLE
Fix some errors, add fields advertiserInfo and finishTime

### DIFF
--- a/boosty/types/poll.py
+++ b/boosty/types/poll.py
@@ -26,6 +26,7 @@ class Poll(BaseObject):
     isMultiple: bool
     counter: int
     isFinished: bool
+    finishTime: int
     id: int
     title: list[str]
     options: list[Option]

--- a/boosty/types/post.py
+++ b/boosty/types/post.py
@@ -1,6 +1,5 @@
 from datetime import datetime
-
-from pydantic import UUID4, HttpUrl
+from typing import Any
 
 from boosty.types.base import BaseObject
 from boosty.types.comment import CommentsResponse
@@ -11,6 +10,7 @@ from boosty.types.reactions import Reactions
 from boosty.types.teaser import TeaserContent
 from boosty.types.users import BlogUser
 from boosty.utils.post import Entity, render_text
+from pydantic import UUID4, HttpUrl
 
 
 class Currency(BaseObject):
@@ -91,6 +91,7 @@ class Post(BaseObject):
     """Subscription level for non-free posts"""
 
     poll: Poll | None = None
+    advertiserInfo: Any
     reacted: React | None = None
     """Unknown"""
     isWaitingVideo: bool


### PR DESCRIPTION
First error:
__pydantic_self__.__pydantic_validator__.validate_python(data, self_instance=__pydantic_self__)
pydantic_core._pydantic_core.ValidationError: 14 validation errors for PostsResponse
data.0.advertiserInfo
  Extra inputs are not permitted [type=extra_forbidden, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.5/v/extra_forbidden

My decision: 
I added a filed "advertiserInfo" in class Post. 
But I do not know type of field. I wrote type "Any", because in my examples, i saw these key and values :
{
    "advertiserInfo": None
}

Second error
pydantic_core._pydantic_core.ValidationError: 1 validation error for PostsResponse
data.14.poll.finishTime
  Extra inputs are not permitted [type=extra_forbidden, input_value=1705736160, input_type=int]
    For further information visit https://errors.pydantic.dev/2.5/v/extra_forbidden
  
My decision: 
I added a field "finishTime" in class Poll. It has type only "int"
