### PR TITLE
Update media_types.py

### DIFF
--- a/boosty/types/media_types.py
+++ b/boosty/types/media_types.py
@@ -93,6 +93,10 @@ class Audio(FileBase):
 
     fileType: Literal["MP3"] | None = None
 
+    timeCode: int | None = None  # TODO
+    viewsCounter: int | None = None  # TODO
+    showViewsCounter: bool | None = None  # TODO
+
 
 class Video(FileBase):
     type: Literal["ok_video"]


### PR DESCRIPTION
3 optinos in Audio same as Video sometimes happens.

On this errors
pydantic_core._pydantic_core.ValidationError: 3 validation errors for Post
data.0.audio_file.showViewsCounter
  Extra inputs are not permitted [type=extra_forbidden, input_value=False, input_type=bool]
    For further information visit https://errors.pydantic.dev/2.5/v/extra_forbidden
data.0.audio_file.viewsCounter
  Extra inputs are not permitted [type=extra_forbidden, input_value=0, input_type=int]
    For further information visit https://errors.pydantic.dev/2.5/v/extra_forbidden
data.0.audio_file.timeCode
  Extra inputs are not permitted [type=extra_forbidden, input_value=0, input_type=int]
    For further information visit https://errors.pydantic.dev/2.5/v/extra_forbidden